### PR TITLE
Remove and update badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p>
 <img src="https://img.shields.io/badge/os-macOS/Linux-green.svg?style=flat" alt="macOS/Linux">
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.4-orange.svg?style=flat" alt="Swift 5.4 Compatible">
+<img src="https://img.shields.io/badge/swift-5.8.1-orange.svg?style=flat" alt="Swift 5.8.1 Compatible">
 </a>
 <a href="https://github.com/swiftfiddle/swiftfiddle-web/blob/master/LICENSE">
 <img src="https://img.shields.io/badge/license-MIT-yellow.svg?style=flat" alt="MIT">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 <p>
-<a href="https://github.com/swiftfiddle/swiftfiddle-web/actions">
-<img src="https://github.com/swiftfiddle/swiftfiddle-web/workflows/CI/badge.svg">
-</a>
 <img src="https://img.shields.io/badge/os-macOS/Linux-green.svg?style=flat" alt="macOS/Linux">
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-5.4-orange.svg?style=flat" alt="Swift 5.4 Compatible">


### PR DESCRIPTION
# 変更点
- 非表示になっているバッジを削除：このバッジを表示してほしいなどがありましたら、コメントいただくと修正します。
- Swiftバッジのバージョンアップ：Swift 5.8.1に変更しました。

# 利益
- READMEがスッキリします。
- 使われているSwiftのバージョンが一目でわかります。

------

# Changes
- Remove hidden badge: If you have any requests to show this badge, etc., please comment and we will fix it.
- Swift badge upgrade: changed to Swift 5.8.1.

# Profit
- README will be cleaner.
- You can see at a glance which version of Swift is being used.